### PR TITLE
Extend IsProd with `divert`

### DIFF
--- a/env.go
+++ b/env.go
@@ -37,9 +37,9 @@ func Set(name string) {
 	Env = name
 }
 
-// IsProd returns true if the current environment is `production` or `prod`.
+// IsProd returns true if the current environment is `production` or `prod` or `divert`.
 func IsProd() bool {
-	return Env == "production" || Env == "prod"
+	return Env == "production" || Env == "prod" || Env == "divert"
 }
 
 // IsDevel returns true if the current environment is `development`, `devel` or


### PR DESCRIPTION
The change is to extend `production` environment with `divert` value.
No `IsDivert` introduced to keep a behavior for diverts the same as for production builds.

Ticket: https://remerge.atlassian.net/browse/CORE-755